### PR TITLE
Changed to kCGImageAlphaPremultipliedLast

### DIFF
--- a/FXBlurView/FXBlurView.h
+++ b/FXBlurView/FXBlurView.h
@@ -76,4 +76,3 @@
 
 
 #pragma GCC diagnostic pop
-

--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -61,8 +61,8 @@
     size_t pixelsHigh = CGImageGetHeight(inImage);
     // Declare the number of bytes per row. Each pixel in the bitmap in this
     // example is represented by 4 bytes; 8 bits each of red, green, blue, and alpha.
-    int bitmapBytesPerRow = (pixelsWide * 4);
-    int bitmapByteCount = (bitmapBytesPerRow * pixelsHigh);
+    size_t bitmapBytesPerRow = (pixelsWide * 4);
+    size_t bitmapByteCount = (bitmapBytesPerRow * pixelsHigh);
     // Use the generic RGB color space.
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     if (colorSpace == NULL) {
@@ -87,7 +87,7 @@
                                                  8,      // bits per component
                                                  bitmapBytesPerRow,
                                                  colorSpace,
-                                                 (CGBitmapInfo) kCGImageAlphaPremultipliedFirst);
+                                                 (CGBitmapInfo) kCGImageAlphaPremultipliedLast);
     if (context == NULL) {
         free(bitmapData);
         NSLog(@"Context not created!");
@@ -132,8 +132,15 @@
     buffer2.data = malloc(bytes);
     
     //create temp buffer
-    void *tempBuffer = malloc((size_t)vImageBoxConvolve_ARGB8888(&buffer1, &buffer2, NULL, 0, 0, boxSize, boxSize,
-                                                                 NULL, kvImageEdgeExtend + kvImageGetTempBufferSize));
+    void *tempBuffer = malloc((size_t)vImageBoxConvolve_ARGB8888(&buffer1,
+                                                                 &buffer2,
+                                                                 NULL,
+                                                                 0,
+                                                                 0,
+                                                                 boxSize,
+                                                                 boxSize,
+                                                                 NULL,
+                                                                 kvImageEdgeExtend + kvImageGetTempBufferSize));
     
     //copy image data
     CFDataRef dataSource = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));
@@ -156,9 +163,13 @@
     free(tempBuffer);
     
     //create image context from buffer
-    CGContextRef ctx = CGBitmapContextCreate(buffer1.data, buffer1.width, buffer1.height,
-                                             8, buffer1.rowBytes, CGImageGetColorSpace(imageRef),
-                                             CGImageGetBitmapInfo(imageRef));
+    CGContextRef ctx = CGBitmapContextCreate(buffer1.data,
+                                             buffer1.width,
+                                             buffer1.height,
+                                             8,
+                                             buffer1.rowBytes,
+                                             CGImageGetColorSpace(imageRef),
+                                             (CGBitmapInfo) kCGImageAlphaPremultipliedLast);
     
     //apply tint
     if (tintColor && CGColorGetAlpha(tintColor.CGColor) > 0.0f)
@@ -329,7 +340,7 @@
                 }
             }
         }
-
+        
         //try again, delaying until the time when the next view needs an update.
         self.viewIndex = 0;
         [self performSelector:@selector(updateAsynchronously)
@@ -546,7 +557,7 @@
         {
             CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:key];
             animation.fromValue = [layer.presentationLayer valueForKey:key];
-    
+            
             //CAMediatiming attributes
             animation.beginTime = action.beginTime;
             animation.duration = action.duration;


### PR DESCRIPTION
I was getting the following error on some ARGB8888 images:

```
<Error>: CGBitmapContextCreate: unsupported parameter combination: 8 integer bits/component; 32 bits/pixel; 3-component color space; kCGImageAlphaLast; 3000 bytes/row.
<Error>: CGBitmapContextCreateImage: invalid context 0x0. This is a serious error. This application, or a library it uses, is using an invalid context  and is thereby contributing to an overall degradation of system stability and reliability. This notice is a courtesy: please fix this problem. It will become a fatal error in an upcoming update.
```

Switching to kCGImageAlphaPremultipliedLast instead of CGImageGetBitmapInfo(imageRef) fixed this issue.

Additionally on non-ARGB8888 images - for example: CGImageGetBitsPerPixel(imageRef) == 8 I noticed that the image colours were inverted (light blue appeared light red). Switching from kCGImageAlphaPremultipliedFirst to kCGImageAlphaPremultipliedLast fixed this.
