### PR TITLE
fixed crash for RGBA images (PNG)

### DIFF
--- a/FXBlurView/FXBlurView.m
+++ b/FXBlurView/FXBlurView.m
@@ -49,9 +49,14 @@
 @implementation UIImage (FXBlurView)
 
 - (BOOL)isARGB8888:(CGImageRef)imageRef {
+	CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(imageRef);
+	    BOOL isAlphaOnFirstPlace = ( kCGImageAlphaPremultipliedFirst == alphaInfo || kCGImageAlphaFirst == alphaInfo
+	                        || kCGImageAlphaNoneSkipFirst == alphaInfo || kCGImageAlphaNoneSkipLast == alphaInfo);
+	
     return (CGImageGetBitsPerPixel(imageRef) == 32
             && CGImageGetBitsPerComponent(imageRef) == 8
-            && (CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask));
+            && (CGImageGetBitmapInfo(imageRef) & kCGBitmapAlphaInfoMask)
+			&& isAlphaOnFirstPlace);
 }
 
 


### PR DESCRIPTION
the  -isARGB8888: method was not perfect - it didn't triggered for the case of RGBA (PNG images) - as result - UIImage extension for creating blurred images crashed after failure to setup image context.
